### PR TITLE
Add H1 heading and touch-aware links to soundchangebasque page

### DIFF
--- a/teaching/soundchangebasque/index.qmd
+++ b/teaching/soundchangebasque/index.qmd
@@ -3,75 +3,98 @@ title: "44200 Advanced course in Sound Change with a focus on Basque (UChicago 2
 date: "2025-10-06"
 ---
 
+# 44200 Advanced course in Sound Change with a focus on Basque (UChicago 2024-25 Spring)
+
 This graduate seminar is intended for students with a background in phonetics and (historical) phonology and an interest in either sound change or the sound patterns of Basque. In this seminar, we will discuss many of the linguistic aspects relevant to theories of sound change with a focus on the Basque language (with occasional case studies from other endangered languages such as Ribagorzan Aragonese or Lakota). Key topics will include phonetically-based sound change, synchronic variation as the seed of change, the role of contact, the advantages of studying change from different perspectives, typologically rare sound changes, and the importance of the precise phonetic documentation of endangered languages for sound change typology and linguistic theory overall.
 
 The seminar was offered at the University of Chicago during the Spring Quarter of 2025.
 
 ## Course topics
 
-*   Syllabus 2025 [pdf](/static/files/SyllabusUChicago2025.pdf)
+*   Syllabus 2025
+  <div class="touch-aware-links">
+    <a href="/static/files/SyllabusUChicago2025.pdf" class="pdf-link"><i class="ai ai-open-access"></i><span class="link-text">PDF</span></a>
+  </div>
 
 ## 1. Introduction
 
 *   Methodology
 *   The sound structure of Basque
 
-[slides](/static/files/1-Intro&BasquePhon.pdf)
+<div class="touch-aware-links">
+  <a href="/static/files/1-Intro&BasquePhon.pdf" class="slides-link"><i class="fas fa-file-powerpoint"></i><span class="link-text">Slides</span></a>
+</div>
 
 ## 2. Documenting endangered varieties
 
 *   Mixean Basque
 *   Zuberoan Basque
 
-[slides](/static/files/2-Zuberoan&Mixean.pdf)
+<div class="touch-aware-links">
+  <a href="/static/files/2-Zuberoan&Mixean.pdf" class="slides-link"><i class="fas fa-file-powerpoint"></i><span class="link-text">Slides</span></a>
+</div>
 
 ## 3. Looking at a 'weird' sound change from a phonetic perspective: Metathesis
 
 *   Everything we know about metathesis
 *   Other cases of metathesis in Basque
 
-[slides](/static/files/3-Metathesis.pdf)
+<div class="touch-aware-links">
+  <a href="/static/files/3-Metathesis.pdf" class="slides-link"><i class="fas fa-file-powerpoint"></i><span class="link-text">Slides</span></a>
+</div>
 
 ## 4. The role of contact in phonetically-based sound change
 
 *   u-fronting in Zuberoan Basque
 *   Other contact-triggered sound patterns in Basque
 
-[slides](/static/files/4-RoleOfContact.pdf)
+<div class="touch-aware-links">
+  <a href="/static/files/4-RoleOfContact.pdf" class="slides-link"><i class="fas fa-file-powerpoint"></i><span class="link-text">Slides</span></a>
+</div>
 
 ## 5. Analyzing a sound change from multiple sources and angles
 
 *   Basque sibilant merger with acoustic data
 *   Basque sibilant merger in a 18th century dictionary
 
-[slides](/static/files/5-MultipleSources.pdf)
+<div class="touch-aware-links">
+  <a href="/static/files/5-MultipleSources.pdf" class="slides-link"><i class="fas fa-file-powerpoint"></i><span class="link-text">Slides</span></a>
+</div>
 
 ## 6. Synchronic variation as the seed of sound change: Cluster palatalization
 
 *   Cluster palatalization in Romance
 *   Borrowing into Basque
 
-[slides](/static/files/6-SeedOfSoundChange.pdf)
+<div class="touch-aware-links">
+  <a href="/static/files/6-SeedOfSoundChange.pdf" class="slides-link"><i class="fas fa-file-powerpoint"></i><span class="link-text">Slides</span></a>
+</div>
 
 ## 7. Typologically rare sound patterns: /h/ vs. /h̃/ in Basque
 
 *   Nasalance study of Zuberoan aspiration data
 *   Acoustic study of Mixean aspiration data
 
-[slides](/static/files/1-Intro&BasquePhon.pdf)
+<div class="touch-aware-links">
+  <a href="/static/files/1-Intro&BasquePhon.pdf" class="slides-link"><i class="fas fa-file-powerpoint"></i><span class="link-text">Slides</span></a>
+</div>
 
 ## 8. Typologically rare sound changes: Final voicing
 
 *   Final obstruent voicing in Lakota
 *   The importance of endangered languages and varieties for linguistic theory
 
-[slides](/static/files/8-FinalVoicing.pdf)
+<div class="touch-aware-links">
+  <a href="/static/files/8-FinalVoicing.pdf" class="slides-link"><i class="fas fa-file-powerpoint"></i><span class="link-text">Slides</span></a>
+</div>
 
 ## 9. Prosodic change
 
 *   The reconstruction of the Basque prosodic systems
 *   Implications for synchronic analysis: Pitch accent in Northern Bizkaian Basque
 
-[slides](/static/files/9-HistoryOfProsody.pdf)
+<div class="touch-aware-links">
+  <a href="/static/files/9-HistoryOfProsody.pdf" class="slides-link"><i class="fas fa-file-powerpoint"></i><span class="link-text">Slides</span></a>
+</div>
 
 ---


### PR DESCRIPTION
This PR updates the soundchangebasque teaching page to:

- Add an H1 heading with the page title for better accessibility and consistency
- Convert all PDF/slides links to touch-aware format using `touch-aware-links` divs with proper icons
- Match the styling and behavior of other teaching pages (euskalfono, soundchange)